### PR TITLE
Extra arguments for fetch function

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -31,7 +31,7 @@ export default class Action {
       const schema: Schema = await context.loadSchema();
 
       const multiple: boolean = Schema.returnsConnection(schema.getMutation(name)!);
-      const query = QueryBuilder.buildQuery('mutation', model, name, variables, multiple);
+      const query = QueryBuilder.buildQuery('mutation', model, name, variables, undefined, multiple);
 
       // Send GraphQL Mutation
       let newData = await Context.getInstance().apollo.request(model, query, variables, true);

--- a/src/actions/fetch.ts
+++ b/src/actions/fetch.ts
@@ -34,15 +34,18 @@ export default class Fetch extends Action {
     const filter = params && params.filter ?
       Transformer.transformOutgoingData(model, params.filter, Object.keys(params.filter)) : {};
 
+    const extraArgs = params && params.extraArgs ?
+      Transformer.transformOutgoingData(model, params.extraArgs, Object.keys(params.extraArgs)) : {};
+
     const bypassCache = params && params.bypassCache;
 
     // When the filter contains an id, we query in singular mode
     const multiple: boolean = !filter['id'];
     const name: string = NameGenerator.getNameForFetch(model, multiple);
-    const query = QueryBuilder.buildQuery('query', model, name, filter, multiple, multiple);
+    const query = QueryBuilder.buildQuery('query', model, name, filter, extraArgs, multiple, multiple);
 
     // Send the request to the GraphQL API
-    const data = await context.apollo.request(model, query, filter, false, bypassCache as boolean);
+    const data = await context.apollo.request(model, query, { ...filter, ...extraArgs }, false, bypassCache as boolean);
 
     // Insert incoming data into the store
     return Store.insertData(data, dispatch);

--- a/src/actions/query.ts
+++ b/src/actions/query.ts
@@ -44,7 +44,7 @@ export default class Query extends Action {
       const multiple: boolean = Schema.returnsConnection(schema.getQuery(name)!);
 
       // Build query
-      const query = QueryBuilder.buildQuery('query', model, name, filter, multiple, false);
+      const query = QueryBuilder.buildQuery('query', model, name, filter, undefined, multiple, false);
 
       // Send the request to the GraphQL API
       const data = await context.apollo.request(model, query, filter, false, bypassCache as boolean);

--- a/src/graphql/query-builder.ts
+++ b/src/graphql/query-builder.ts
@@ -17,6 +17,7 @@ export default class QueryBuilder {
    * @param {Model|string} model The model to use
    * @param {boolean} multiple Determines whether plural/nodes syntax or singular syntax is used.
    * @param {Arguments} args The args that will be passed to the query field ( user(role: $role) )
+   * @param {Arguments} extraArgs Extra args to be passed to the field
    * @param {Array<Model>} path The relations in this list are ignored (while traversing relations).
    *                                    Mainly for recursion
    * @param {string} name Optional name of the field. If not provided, this will be the model name
@@ -30,6 +31,7 @@ export default class QueryBuilder {
   public static buildField (model: Model | string,
                      multiple: boolean = true,
                      args?: Arguments,
+                     extraArgs?: Arguments,
                      path: Array<string> = [],
                      name?: string,
                      filter: boolean = false,
@@ -41,7 +43,22 @@ export default class QueryBuilder {
     name = name ? name : model.pluralName;
     const field = context.schema!.getMutation(name, true) || context.schema!.getQuery(name, true);
 
-    let params: string = this.buildArguments(model, args, false, filter, allowIdFields, field);
+    let params: string = '';
+    const argumentsString = this.buildArguments(model, args, false, filter, allowIdFields, field);
+    const extraArgumentsString = this.buildArguments(model, extraArgs, false, false, allowIdFields, field);
+    if (argumentsString.length > 0 || extraArgumentsString.length > 0) {
+      params = '(';
+      if (argumentsString.length > 0) {
+        params += argumentsString;
+      }
+      if (argumentsString.length > 0 && extraArgumentsString.length > 0) {
+        params += ',';
+      }
+      if (extraArgumentsString.length > 0) {
+        params += extraArgumentsString;
+      }
+      params += ')';
+    }
     path = path.length === 0 ? [model.singularName] : path;
 
     const fields = `
@@ -93,12 +110,13 @@ export default class QueryBuilder {
    * @param {Model | string} model The model this query or mutation affects. This mainly determines the query fields.
    * @param {string} name Optional name of the query/mutation. Will overwrite the name from the model.
    * @param {Arguments} args Arguments for the query
+   * @param {Arguments} extraArgs Extra Arguments for the query
    * @param {boolean} multiple Determines if the root query field is a connection or not (will be passed to buildField)
    * @param {boolean} filter When true the query arguments are passed via a filter object.
    * @returns {any} Whatever gql() returns
    */
-  public static buildQuery (type: string, model: Model | string, name?: string, args?: Arguments, multiple?: boolean,
-                            filter?: boolean) {
+  public static buildQuery (type: string, model: Model | string, name?: string, args?: Arguments, extraArgs?: Arguments,
+                            multiple?: boolean, filter?: boolean) {
     const context = Context.getInstance();
 
     // model
@@ -125,9 +143,25 @@ export default class QueryBuilder {
     const field = context.schema!.getMutation(name, true) || context.schema!.getQuery(name, true);
 
     // build query
+    const argumentsString = this.buildArguments(model, args, true, filter, true, field);
+    const extraArgumentsString = this.buildArguments(model, extraArgs, true, false, true, field);
+    let params: string = '';
+    if (argumentsString.length > 0 || extraArgumentsString.length > 0) {
+      params = '(';
+      if (argumentsString.length > 0) {
+        params += argumentsString;
+      }
+      if (argumentsString.length > 0 && extraArgumentsString.length > 0) {
+        params += ',';
+      }
+      if (extraArgumentsString.length > 0) {
+        params += extraArgumentsString;
+      }
+      params += ')';
+    }
     const query: string =
-      `${type} ${upcaseFirstLetter(name)}${this.buildArguments(model, args, true, filter, true, field)} {\n` +
-      `  ${this.buildField(model, multiple, args, [], name, filter, true)}\n` +
+      `${type} ${upcaseFirstLetter(name)}${params} {\n` +
+      `  ${this.buildField(model, multiple, args, extraArgs, [], name, filter, true)}\n` +
       `}`;
 
     return gql(query);
@@ -212,7 +246,7 @@ export default class QueryBuilder {
 
       if (!first) {
         if (!signature && filter) returnValue = `filter: { ${returnValue} }`;
-        returnValue = `(${returnValue})`;
+        returnValue = `${returnValue}`;
       }
     }
 
@@ -330,7 +364,7 @@ export default class QueryBuilder {
         const newPath = path.slice(0);
         newPath.push(relatedModel.singularName);
 
-        relationQueries.push(this.buildField(relatedModel, Model.isConnection(field), undefined, newPath, name, false));
+        relationQueries.push(this.buildField(relatedModel, Model.isConnection(field), undefined, undefined, newPath, name, false));
       }
     });
 

--- a/src/support/interfaces.ts
+++ b/src/support/interfaces.ts
@@ -24,6 +24,7 @@ export interface ActionParams {
   rootState: any;
   state: RootState;
   filter?: Filter;
+  extraArgs?: any;
   id?: number;
   data?: Data;
   args?: Arguments;

--- a/src/vuex-orm-graphql.ts
+++ b/src/vuex-orm-graphql.ts
@@ -54,10 +54,10 @@ export default class VuexORMGraphQL {
     const context = Context.getInstance();
 
     // Register static model convenience methods
-    (context.components.Model as (typeof PatchedModel)).fetch = async function (filter: any, bypassCache = false) {
+    (context.components.Model as (typeof PatchedModel)).fetch = async function (filter?: any, extraArgs?: any, bypassCache = false) {
       let filterObj = filter;
       if (!_.isPlainObject(filterObj)) filterObj = { id: filter };
-      return this.dispatch('fetch', { filter: filterObj, bypassCache });
+      return this.dispatch('fetch', { filter: filterObj, extraArgs, bypassCache });
     };
 
     (context.components.Model as (typeof PatchedModel)).mutate = async function (params: ActionParams) {

--- a/test/unit/QueryBuilder.spec.js
+++ b/test/unit/QueryBuilder.spec.js
@@ -30,7 +30,7 @@ describe('QueryBuilder', () => {
         }]
       }, true, false, false);
 
-      expect(args).toEqual('($content: String!, $title: String!, $otherId: ID!, $author: UserInput!)');
+      expect(args).toEqual('$content: String!, $title: String!, $otherId: ID!, $author: UserInput!');
 
 
 
@@ -39,7 +39,7 @@ describe('QueryBuilder', () => {
         itemIds: [1, 2, 4, 9, 68]
       }, true, false, true, context.schema.getMutation('reorderItems'));
 
-      expect(args).toEqual('($id: ID!, $itemIds: [ID]!)');
+      expect(args).toEqual('$id: ID!, $itemIds: [ID]!');
     });
 
     it('can generate fields with variables', () => {
@@ -57,8 +57,8 @@ describe('QueryBuilder', () => {
         }]
       }, false, false, false);
 
-      expect(args).toEqual('(content: $content, title: $title, otherId: $otherId, author: $author, ' +
-        'crazyIDList: $crazyIDList)');
+      expect(args).toEqual('content: $content, title: $title, otherId: $otherId, author: $author, ' +
+        'crazyIDList: $crazyIDList');
     });
 
     it('can generate filter field with variables', () => {
@@ -71,7 +71,7 @@ describe('QueryBuilder', () => {
         author: { __type: 'User' }
       }, false, true, false);
 
-      expect(args).toEqual('(filter: { content: $content, title: $title, otherId: $otherId, author: $author })');
+      expect(args).toEqual('filter: { content: $content, title: $title, otherId: $otherId, author: $author }');
     });
   });
 
@@ -150,7 +150,7 @@ query test {
 
   describe('.buildField', () => {
     it('generates query fields for all model fields and relations', () => {
-      let query = QueryBuilder.buildField(context.getModel('user'), true, { age: 32 }, undefined, undefined, true);
+      let query = QueryBuilder.buildField(context.getModel('user'), true, { age: 32 }, undefined, undefined, undefined, true);
       query = prettify(`query users { ${query} }`).trim();
 
       expect(query).toEqual(`
@@ -175,7 +175,7 @@ query users {
       it('contains a nodes field when connection mode is nodes', () => {
         context.connectionQueryMode = 'nodes';
 
-        let query = QueryBuilder.buildField(context.getModel('user'), true, { age: 32 }, undefined, undefined, true);
+        let query = QueryBuilder.buildField(context.getModel('user'), true, { age: 32 }, undefined, undefined, undefined, true);
         query = prettify(`query users { ${query} }`).trim();
 
         expect(query).toEqual(`
@@ -199,7 +199,7 @@ query users {
       it('contains a edges field when connection mode is edges', () => {
         context.connectionQueryMode = 'edges';
 
-        let query = QueryBuilder.buildField(context.getModel('user'), true, { age: 32 }, undefined, undefined, true);
+        let query = QueryBuilder.buildField(context.getModel('user'), true, { age: 32 }, undefined, undefined, undefined, true);
         query = prettify(`query users { ${query} }`).trim();
 
         expect(query).toEqual(`
@@ -225,7 +225,7 @@ query users {
       it('contains no meta field when connection mode is plain', () => {
         context.connectionQueryMode = 'plain';
 
-        let query = QueryBuilder.buildField(context.getModel('user'), true, { age: 32 }, undefined, undefined, true);
+        let query = QueryBuilder.buildField(context.getModel('user'), true, { age: 32 }, undefined, undefined, undefined, true);
         query = prettify(`query users { ${query} }`).trim();
 
         expect(query).toEqual(`
@@ -251,7 +251,7 @@ query users {
     it('generates a complete query for a model', () => {
       const args = { title: 'Example Post 1' };
 
-      let query = QueryBuilder.buildQuery('query', context.getModel('post'), null, args, true, true);
+      let query = QueryBuilder.buildQuery('query', context.getModel('post'), null, args, undefined, true, true);
       query = prettify(query.loc.source.body);
 
       expect(query).toEqual(`
@@ -301,7 +301,7 @@ query Posts($title: String!) {
     it('generates a complete create mutation query for a model', () => {
       const variables = { post: { id: 15, authorId: 2, title: 'test', content: 'even more test' } };
       let post = context.getModel('post');
-      let query = QueryBuilder.buildQuery('mutation', post, 'createPost', variables, false);
+      let query = QueryBuilder.buildQuery('mutation', post, 'createPost', variables, undefined, false);
       query = prettify(query.loc.source.body);
 
       expect(query).toEqual(`
@@ -349,7 +349,7 @@ mutation CreatePost($post: PostInput!) {
     it('generates a complete update mutation query for a model', () => {
       const variables = { id: 2, post: { id: 2, authorId: 1, title: 'test', content: 'Even more test' } };
       let post = context.getModel('post');
-      let query = QueryBuilder.buildQuery('mutation', post, 'updatePost', variables, false);
+      let query = QueryBuilder.buildQuery('mutation', post, 'updatePost', variables, undefined, false);
       query = prettify(query.loc.source.body);
 
       expect(query).toEqual(`
@@ -397,7 +397,7 @@ mutation UpdatePost($id: ID!, $post: PostInput!) {
 
 
     it('generates a complete delete mutation query for a model', () => {
-      let query = QueryBuilder.buildQuery('mutation', context.getModel('user'), 'deleteUser', { id: 15 });
+      let query = QueryBuilder.buildQuery('mutation', context.getModel('user'), 'deleteUser', { id: 15 }, undefined);
       query = prettify(query.loc.source.body);
 
       expect(query).toEqual(`


### PR DESCRIPTION
A first step to allowing pagination would be to make it possible to include extra arguments for fetch and all relevant functions. This will allow users to make a custom pagination layer if needed.
This partially solves #31.

Example for this:
`Post.fetch({ name: 'test' }, { first: 5 })`