### PR TITLE
Fixes some broken documentation links

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -34,10 +34,10 @@ The following table lists all actions and what they do:
 
 CRUD | Vuex Only | Persist to GraphQL API
 --| -- | --
-**R**EAD | [`find()`](https://vuex-orm.github.io/vuex-orm/store/retrieving-data.html#get-single-data), [`all()`](https://vuex-orm.github.io/vuex-orm/store/retrieving-data.html#get-all-data), [`query()`](https://vuex-orm.github.io/vuex-orm/store/retrieving-data.html#query-builder) | [`fetch()`](fetch.md)
-**C**REATE | [`create()`](https://vuex-orm.github.io/vuex-orm/store/inserting-and-updating-data.html#inserts) or [`insert()`](https://vuex-orm.github.io/vuex-orm/store/inserting-and-updating-data.html#inserts) | [`$persist()`](persist.md)
-**U**PDATE | [`$update()`](https://vuex-orm.github.io/vuex-orm/store/inserting-and-updating-data.html#updates) | [`$push()`](push.md)
-**D**ELETE | [`$delete()`](https://vuex-orm.github.io/vuex-orm/store/deleting-data.html) | [`$destroy()`](destroy.md)
+**R**EAD | [`find()`](https://vuex-orm.github.io/vuex-orm/guide/store/retrieving-data.html#get-single-data), [`all()`](https://vuex-orm.github.io/vuex-orm/guide/store/retrieving-data.html#get-all-data), [`query()`](https://vuex-orm.github.io/vuex-orm/guide/store/retrieving-data.html#query-builder) | [`fetch()`](fetch.md)
+**C**REATE | [`create()`](https://vuex-orm.github.io/vuex-orm/guide/store/inserting-and-updating-data.html#inserts) or [`insert()`](https://vuex-orm.github.io/vuex-orm/guide/store/inserting-and-updating-data.html#inserts) | [`$persist()`](persist.md)
+**U**PDATE | [`$update()`](https://vuex-orm.github.io/vuex-orm/guide/store/inserting-and-updating-data.html#updates) | [`$push()`](push.md)
+**D**ELETE | [`$delete()`](https://vuex-orm.github.io/vuex-orm/guide/store/deleting-data.html) | [`$destroy()`](destroy.md)
 
 See the example below to get an idea of how this plugin interacts with Vuex-ORM.
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -100,7 +100,7 @@ Vuex-ORM-GraphQL works with the [Apollo Dev Tools](https://chrome.google.com/web
 It seems that there are several standards within the GraphQL community how connections (fields that returns multiple
 records) are designed. Some do this via a `nodes` field, some via a `edges { nodes }` query and some do neither of them.
 Vuex-ORM-GraphQL tries to be flexible and supports all of them, but the example queries in the documentation work with
-the `nodes` query, don't be irritated. You'll find [more details here](/guide/connection-mode).
+the `nodes` query, don't be irritated. You'll find [more details here](connection-mode.md).
 
 
 ## License

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -34,10 +34,10 @@ The following table lists all actions and what they do:
 
 CRUD | Vuex Only | Persist to GraphQL API
 --| -- | --
-**R**EAD | [`find()`](https://vuex-orm.github.io/vuex-orm/store/retrieving-data.html#get-single-data), [`all()`](https://vuex-orm.github.io/vuex-orm/store/retrieving-data.html#get-all-data), [`query()`](https://vuex-orm.github.io/vuex-orm/store/retrieving-data.html#query-builder) | [`fetch()`](/guide/fetch)
-**C**REATE | [`create()`](https://vuex-orm.github.io/vuex-orm/store/inserting-and-updating-data.html#inserts) or [`insert()`](https://vuex-orm.github.io/vuex-orm/store/inserting-and-updating-data.html#inserts) | [`$persist()`](/guide/persist)
-**U**PDATE | [`$update()`](https://vuex-orm.github.io/vuex-orm/store/inserting-and-updating-data.html#updates) | [`$push()`](/guide/push)
-**D**ELETE | [`$delete()`](https://vuex-orm.github.io/vuex-orm/store/deleting-data.html) | [`$destroy()`](/guide/destroy)
+**R**EAD | [`find()`](https://vuex-orm.github.io/vuex-orm/store/retrieving-data.html#get-single-data), [`all()`](https://vuex-orm.github.io/vuex-orm/store/retrieving-data.html#get-all-data), [`query()`](https://vuex-orm.github.io/vuex-orm/store/retrieving-data.html#query-builder) | [`fetch()`](fetch.md)
+**C**REATE | [`create()`](https://vuex-orm.github.io/vuex-orm/store/inserting-and-updating-data.html#inserts) or [`insert()`](https://vuex-orm.github.io/vuex-orm/store/inserting-and-updating-data.html#inserts) | [`$persist()`](persist.md)
+**U**PDATE | [`$update()`](https://vuex-orm.github.io/vuex-orm/store/inserting-and-updating-data.html#updates) | [`$push()`](push.md)
+**D**ELETE | [`$delete()`](https://vuex-orm.github.io/vuex-orm/store/deleting-data.html) | [`$destroy()`](destroy.md)
 
 See the example below to get an idea of how this plugin interacts with Vuex-ORM.
 
@@ -46,14 +46,14 @@ See the example below to get an idea of how this plugin interacts with Vuex-ORM.
 
 ## Example usage
 
-After [installing](/guide/setup) this plugin you can load data in your component:
+After [installing](setup.md) this plugin you can load data in your component:
 
 ```vue
 <template>
   <ul>
     <li v-for="user in users" :key="user.id">
       {{user.name}}
-      
+
       <a href="#" @click.prevent="destroy(user)">x</a>
     </li>
   </ul>
@@ -62,12 +62,12 @@ After [installing](/guide/setup) this plugin you can load data in your component
 
 <script>
   import User from 'data/models/user';
-  
+
   export default {
     computed: {
       /**
        * Returns all users with reactivity.
-       */ 
+       */
       users: () => User.query().withAll().all()
     },
 
@@ -76,11 +76,11 @@ After [installing](/guide/setup) this plugin you can load data in your component
       // Load all users form the server
       await User.fetch();
     },
-    
-    
+
+
     methods: {
       /**
-      * Deletes the user from Vuex Store and from the server. 
+      * Deletes the user from Vuex Store and from the server.
       */
       async destroy(user) {
         await user.$deleteAndDestroy();

--- a/docs/guide/relationships.md
+++ b/docs/guide/relationships.md
@@ -3,15 +3,15 @@
 [[toc]]
 
 This chapter describes how the GraphQL-Plugin interacts with relationships. All relationships work out of the box.
-We take the examples from the [Vuex-ORM documentation for definition relationships](https://vuex-orm.github.io/vuex-orm/relationships/defining-relationships.html)
+We take the examples from the [Vuex-ORM documentation for definition relationships](https://vuex-orm.github.io/vuex-orm/guide/relationships/defining-relationships.html)
 and show what GraphQL queries will be generated.
 
 
 ## One To One
 
 ::: tip
-See the [One To One section](https://vuex-orm.github.io/vuex-orm/relationships/defining-relationships.html#one-to-one) in the Vuex-ORM documentation.
-::: 
+See the [One To One section](https://vuex-orm.github.io/vuex-orm/guide/relationships/defining-relationships.html#one-to-one) in the Vuex-ORM documentation.
+:::
 
 Is eager loaded automatically.
 
@@ -52,7 +52,7 @@ query Users {
     nodes {
       id
       name
-    
+
       profile {
         id
         age
@@ -73,7 +73,7 @@ query Profiles {
       age
       sex
       userId
-      
+
       user {
         id
         name
@@ -86,10 +86,10 @@ query Profiles {
 ## One To Many
 
 ::: tip
-See the [One To Many section](https://vuex-orm.github.io/vuex-orm/relationships/defining-relationships.html#one-to-many) in the Vuex-ORM documentation.
-::: 
+See the [One To Many section](https://vuex-orm.github.io/vuex-orm/guide/relationships/defining-relationships.html#one-to-many) in the Vuex-ORM documentation.
+:::
 
-BelongsTo is eager loaded automatically while HasMany is not eager loaded. 
+BelongsTo is eager loaded automatically while HasMany is not eager loaded.
 
 **Models:**
 ```javascript
@@ -128,7 +128,7 @@ query Comments {
       id
       postId
       content
-    
+
       post {
         id
         content
@@ -160,8 +160,8 @@ As you can see the comments are not eager loaded.
 ## Many To Many
 
 ::: tip
-See the [Many To Many section](https://vuex-orm.github.io/vuex-orm/relationships/defining-relationships.html#many-to-many) in the Vuex-ORM documentation.
-::: 
+See the [Many To Many section](https://vuex-orm.github.io/vuex-orm/guide/relationships/defining-relationships.html#many-to-many) in the Vuex-ORM documentation.
+:::
 
 Is NOT eager loaded automatically, so we add a eagerLoad field to User.
 
@@ -213,7 +213,7 @@ query Users {
     nodes {
       id
       email
-      
+
       roles {
         nodes {
           id
@@ -244,13 +244,13 @@ query Roles {
 ## Has Many Through
 
 ::: tip
-See the [Has Any Through section](https://vuex-orm.github.io/vuex-orm/relationships/defining-relationships.html#has-many-through) in the Vuex-ORM documentation.
-::: 
+See the [Has Any Through section](https://vuex-orm.github.io/vuex-orm/guide/relationships/defining-relationships.html#has-many-through) in the Vuex-ORM documentation.
+:::
 
 Is NOT eager loaded automatically.
 
 In this example we have a Product which can belong to many ProductGroups. And a ProductGroup can have many Products.
-This is a classical n:m relation type, which we setup via HasManyThrough and a Pivot Model (ProductsProductGroup) 
+This is a classical n:m relation type, which we setup via HasManyThrough and a Pivot Model (ProductsProductGroup)
 
 **Models:**
 ```javascript
@@ -316,7 +316,7 @@ query Users {
       id
       email
       countryId
-      
+
       country {
         id
         name
@@ -334,12 +334,12 @@ query Posts {
       id
       title
       content
-      
+
       user {
         id
         email
         countryId
-        
+
         country {
           id
           name
@@ -354,8 +354,8 @@ query Posts {
 ## Polymorphic Relations
 
 ::: tip
-See the [Polymorphic Relations section](https://vuex-orm.github.io/vuex-orm/relationships/defining-relationships.html#polymorphic-relations) in the Vuex-ORM documentation.
-::: 
+See the [Polymorphic Relations section](https://vuex-orm.github.io/vuex-orm/guide/relationships/defining-relationships.html#polymorphic-relations) in the Vuex-ORM documentation.
+:::
 
 Eager loading behaves like in a normal One To Many or One to One. So we add a `eagerLoad` field to make sure the
 comments are loaded automatically with the post or video.
@@ -412,7 +412,7 @@ query Posts {
       id
       title
       content
-      
+
       comments {
         nodes {
           id
@@ -430,8 +430,8 @@ query Posts {
 ## Many To Many Polymorphic Relations
 
 ::: tip
-See the [Many To Many Polymorphic Relations section](https://vuex-orm.github.io/vuex-orm/relationships/defining-relationships.html#many-to-many-polymorphic-relations) in the Vuex-ORM documentation.
-::: 
+See the [Many To Many Polymorphic Relations section](https://vuex-orm.github.io/vuex-orm/guide/relationships/defining-relationships.html#many-to-many-polymorphic-relations) in the Vuex-ORM documentation.
+:::
 
 Eager loading behaves the same as in a normal Many To Many: Nothing is eager loaded automatically. So we add a
 `eagerLoad` field to make sure the tags are loaded automatically with the post or video.
@@ -499,7 +499,7 @@ query Posts {
       id
       title
       content
-      
+
       tags {
         nodes {
           id

--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -37,7 +37,7 @@ These are the possible options to pass when calling `VuexORM.use()`:
   This can be a static object or a function, returning a object, which will be called before a request is made.
 - `credentials` (optional, default: `same-origin`) Credentials Policy. See [apollo-link-http])(https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-http#options)
 - `useGETForQueries` (optional, default: `false`) Use GET for queries (not for mutations). See [apollo-link-http])(https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-http#options)
-- `connectionQueryMode` (optional, default: `auto`). One of `auto | nodes | edges | plain`. See [Connection Mode](/guide/connection-mode)
+- `connectionQueryMode` (optional, default: `auto`). One of `auto | nodes | edges | plain`. See [Connection Mode](connection-mode.md)
 
 More options will come in future releases.
 

--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -18,7 +18,7 @@ $ npm install --save @vuex-orm/plugin-graphql
 ```
 
 
-After that we setup the plugin. Add this after [registering your models to the database](https://vuex-orm.github.io/vuex-orm/prologue/getting-started.html#register-models-and-modules-to-the-vuex-store):
+After that we setup the plugin. Add this after [registering your models to the database](https://vuex-orm.github.io/vuex-orm/guide/prologue/getting-started.html#register-models-and-modules-to-the-vuex-store):
 
 ```javascript
 import VuexORMGraphQL from '@vuex-orm/plugin-graphql';


### PR DESCRIPTION
New to VuePress - hopefully I did this right.

There were a handful of links in the format of `[link text](/guide/page)` which should (I think) be `[link text](page.md)`.

You'd think that the config.js `baseURL` would kick in here but it doesn't. This fix seems to fix the problem. 