### PR TITLE
Add Items connection mode

### DIFF
--- a/docs/guide/connection-mode.md
+++ b/docs/guide/connection-mode.md
@@ -6,7 +6,7 @@ It seems that there are several standards within the GraphQL community how conne
 records) are designed. Some do this via a `nodes` field, some via a `edges { nodes }` query and some do neither of them.
 Vuex-ORM-GraphQL tries to be flexible and supports all of them.
 
-There are four possible modes: `AUTO`, `NODES`, `EDGES`, `PLAIN`. The Adapter you use will tell the
+There are four possible modes: `AUTO`, `NODES`, `EDGES`, `PLAIN`, `ITEMS`. The Adapter you use will tell the
 plugin which ConnectionMode to use. In the DefaultAdapter this is `AUTO`.
 
 
@@ -22,7 +22,7 @@ In rare cases the automatic detection might fail or report the wrong mode. In th
 manually set the connection mode via a custom adapter. The modes and the resulting
 queries are explained in the next sections.
 
-## Mode 1: `plain` 
+## Mode 1: `plain`
 
 The third mode is the less preferred one due to the lack of meta information. In this case we just plain pass the field
 queries:
@@ -54,8 +54,8 @@ query Users {
 }
 ```
 
- 
-## Mode 3: `edges` 
+
+## Mode 3: `edges`
 
 This mode uses a `edges` not to query the edge an then query the `node` within that edge:
 
@@ -68,6 +68,22 @@ query Users {
         email
         name
       }
+    }
+  }
+}
+```
+
+## Mode 4: `items`
+
+This is the mode used for handling the shape of AWS AppSync queries. Using `items` (or letting the plugin auto detect this mode) will lead to the following query when calling `User.fetch()`:
+
+```
+query Users {
+  users {
+    items {
+      id
+      email
+      name
     }
   }
 }

--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -69,7 +69,7 @@ const options = {
       fetchPolicy: 'cache-and-network'
     }
   },
-  connectionQueryMode: 'nodes',
+  connectionQueryMode: 'items',
   database: database,
   url: awsexports.aws_appsync_graphqlEndpoint,
   includeExtensions: true,

--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -4,7 +4,8 @@ export enum ConnectionMode {
   AUTO,
   PLAIN,
   NODES,
-  EDGES
+  EDGES,
+  ITEMS
 }
 
 export enum ArgumentMode {

--- a/src/common/context.ts
+++ b/src/common/context.ts
@@ -85,7 +85,7 @@ export default class Context {
   private schemaWillBeLoaded: Promise<Schema> | undefined;
 
   /**
-   * Defines how to query connections. 'auto' | 'nodes' | 'edges' | 'plain'
+   * Defines how to query connections. 'auto' | 'nodes' | 'edges' | 'plain' | 'items'
    */
   public connectionMode: ConnectionMode = ConnectionMode.AUTO;
 

--- a/src/graphql/query-builder.ts
+++ b/src/graphql/query-builder.ts
@@ -71,6 +71,14 @@ export default class QueryBuilder {
             }
           }
         `;
+      } else if (context.connectionMode === ConnectionMode.ITEMS) {
+        return `
+          ${header} {
+            items {
+              ${fields}
+            }
+          }
+        `;
       } else {
         return `
           ${header} {

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -55,6 +55,8 @@ export default class Schema {
       return ConnectionMode.NODES;
     } else if (connection!.fields!.find(f => f.name === "edges")) {
       return ConnectionMode.EDGES;
+    } else if (connection!.fields!.find(f => f.name === "items")) {
+      return ConnectionMode.ITEMS;
     } else {
       return ConnectionMode.PLAIN;
     }

--- a/src/graphql/transformer.ts
+++ b/src/graphql/transformer.ts
@@ -164,7 +164,7 @@ export default class Transformer {
               result = this.transformIncomingData(data["node"], localModel, mutation, true);
             } else if (data[key].items && context.connectionMode === ConnectionMode.ITEMS) {
               result[pluralize(key)] = this.transformIncomingData(
-                data[key].edges,
+                data[key].items,
                 localModel,
                 mutation,
                 true

--- a/src/graphql/transformer.ts
+++ b/src/graphql/transformer.ts
@@ -162,6 +162,13 @@ export default class Transformer {
               );
             } else if (data["node"] && context.connectionMode === ConnectionMode.EDGES) {
               result = this.transformIncomingData(data["node"], localModel, mutation, true);
+            } else if (data[key].items && context.connectionMode === ConnectionMode.ITEMS) {
+              result[pluralize(key)] = this.transformIncomingData(
+                data[key].edges,
+                localModel,
+                mutation,
+                true
+              );
             } else {
               let newKey = key;
 


### PR DESCRIPTION
This should allow users to support the default shape of AWS AppSync responses:

```
items {
        id
        title
      }
```
