### PR TITLE
Fix some typos

### DIFF
--- a/docs/guide/custom-queries.md
+++ b/docs/guide/custom-queries.md
@@ -21,7 +21,7 @@ way. This might be changed in the future, when we find a better solution.
 ## Model related custom query
 
 You may sometimes want to send custom GraphQL query. We support this via the `query` action. However please notice that
-the convenienceMethods here are named `customMutation` and `$customMutation` due to a name conflict with the `query()`
+the convenienceMethods here are named `customQuery` and `$customQuery` due to a name conflict with the `query()`
 method Vuex-ORM.
 
 ```javascript

--- a/docs/guide/eager-loading.md
+++ b/docs/guide/eager-loading.md
@@ -30,7 +30,7 @@ class User extends Model {
 ## Eager Saving
 
 Similar to the eager loading there is a "eager saving". When saving (via `$persist` or `$push`) a
-record will automatically sends all `belongsTo` related records too to the server.
+record will automatically send all `belongsTo` related records too to the server.
 
 All other related records have to be added to a static field in the model called `eagerSave` to
 have them eagerly saved with persist and push.

--- a/docs/guide/persist.md
+++ b/docs/guide/persist.md
@@ -63,7 +63,7 @@ Like when pushing, all records which are returned replace the respective existin
 
 ## Additional variables
 
-You can pass a object like this: `$perist({ captchaToken: 'asdfasdf' })`. All fields in the object will be passed as
+You can pass a object like this: `$persist({ captchaToken: 'foo' })`. All fields in the object will be passed as
 variables to the mutation.
 
 

--- a/docs/guide/push.md
+++ b/docs/guide/push.md
@@ -57,7 +57,7 @@ Like when persisting, all records which are returned replace the respective exis
 
 ## Additional variables
 
-You can pass a object like this: `$push({ captchaToken: 'asdfasdf' })`. All fields in the object will be passed as
+You can pass a object like this: `$push({ captchaToken: 'foo' })`. All fields in the object will be passed as
 variables to the mutation.
 
 

--- a/docs/guide/relationships.md
+++ b/docs/guide/relationships.md
@@ -433,7 +433,7 @@ query Posts {
 See the [Many To Many Polymorphic Relations section](https://vuex-orm.github.io/vuex-orm/guide/relationships/defining-relationships.html#many-to-many-polymorphic-relations) in the Vuex-ORM documentation.
 :::
 
-Eager loading behaves the same as in a normal Many To Many: Nothing is eager loaded automatically. So we add a
+Eager loading behaves the same as in a normal Many To Many: nothing is eager loaded automatically. So we add a
 `eagerLoad` field to make sure the tags are loaded automatically with the post or video.
 
 **Models:**


### PR DESCRIPTION
perist -> persist
Looks like `customMutation` is meant to be `customQuery` in the first paragraph [here](https://vuex-orm.github.io/plugin-graphql/guide/custom-queries.html#model-related-custom-query).

Also includes a few small changes aimed to improve readability